### PR TITLE
[Refactoring] WebDriver를 정적 싱글톤 팩토리 패턴 적용해서 생성하도록 수정

### DIFF
--- a/src/main/java/com/crawling/domain/InterParkContent.java
+++ b/src/main/java/com/crawling/domain/InterParkContent.java
@@ -119,7 +119,8 @@ public class InterParkContent {
     }
 
     public void addImageFilePath() throws IOException {
-        this.imageFilePath = InterParkCrawler.saveImgFile("http://ticket.interpark.com/" + this.groupCode);
+        String imageRootPath = "http://ticket.interpark.com/";
+        this.imageFilePath = InterParkCrawler.saveImgFile(imageRootPath + this.groupCode);
     }
 
     public void setDeleteflag(DeleteFlag deleteflag) {

--- a/src/main/java/com/crawling/utill/WebDriveFactory.java
+++ b/src/main/java/com/crawling/utill/WebDriveFactory.java
@@ -1,0 +1,24 @@
+package com.crawling.utill;
+
+import lombok.NoArgsConstructor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+public class WebDriveFactory {
+    private static WebDriver webDriver;
+
+    public static WebDriver getChromeDriver() {
+        if (webDriver == null) {
+            chromeDriverFactory();
+        }
+        return webDriver;
+    }
+
+    private static void chromeDriverFactory() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--headless");
+        System.setProperty("webdriver.chrome.driver", "src/main/resources/chromedriver.exe");
+        webDriver = new ChromeDriver(chromeOptions);
+    }
+}

--- a/src/test/java/com/crawling/service/TestinterparkCrawler.java
+++ b/src/test/java/com/crawling/service/TestinterparkCrawler.java
@@ -14,9 +14,6 @@ import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -98,18 +95,12 @@ public class TestinterparkCrawler {
 
     @Test
     public void testFIndPrice() throws Exception {
-        ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.addArguments("--headless");
-
-        System.setProperty("webdriver.chrome.driver", "src/main/resources/chromedriver.exe");
-        WebDriver driver = new ChromeDriver(chromeOptions);
-
         for (InterparkType dtype : InterparkType.values()) {
             List<InterParkContent> ls;
             ls = interparkCrawling.crawling(dtype).stream().limit(10).collect(Collectors.toList());
             for (InterParkContent interParkDTO : ls) {
                 try {
-                    interparkCrawling.findPrice(driver, interParkDTO);
+                    interparkCrawling.findPrice(interParkDTO);
                 } catch (Exception e) {
                     log.info(interParkDTO.toString());
                     log.error(e.getMessage());


### PR DESCRIPTION
WebDriver를 메소드 파라미더에 포함시키던 것을 WebDriver를 사용하는 메소드(ex. findPrice)의 지역변수로 포함해서 의존성 줄임.
WebDriver.getXXXX() 메소드를 호출하더라도 싱글톤이기 때문에 오버헤드 없음.